### PR TITLE
Enabling cross-publishing for 2.11

### DIFF
--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -23,7 +23,7 @@ object BuildSettings {
     version       := "0.1.0",
     description   := "Scala wrapper for MaxMind GeoIP library",
     scalaVersion  := "2.9.3",
-    crossScalaVersions := Seq("2.9.3", "2.10.4"),
+    crossScalaVersions := Seq("2.9.3", "2.10.4", "2.11.2"),
     scalacOptions := Seq("-deprecation", "-encoding", "utf8"),
     resolvers     ++= Dependencies.resolutionRepos
   )

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -24,7 +24,7 @@ object Dependencies {
     object collUtils {
       val _29   = "5.3.10"
       val _210  = "6.3.4"
-      val _211  = "6.12.1"     
+      val _211  = "6.20.0"     
     }
     object specs2 {
       val _29   = "1.12.4.1"
@@ -38,7 +38,6 @@ object Dependencies {
     object collUtils {
       val _29   = "com.twitter"                %  "util-collection"      % V.collUtils._29
       val _210  = "com.twitter"                %% "util-collection"      % V.collUtils._210
-      // Not yet released
       val _211  = "com.twitter"                %% "util-collection"      % V.collUtils._211
     }
     object specs2 {


### PR DESCRIPTION
Twitter has released collection utils for Scala 2.11 with the version 6.20.0
