### PR TITLE
Integrate scalafmt (close #66)

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,0 +1,30 @@
+style = defaultWithAlign
+maxColumn = 100
+
+docstrings = JavaDoc
+optIn.breakChainOnFirstMethodDot = true
+spaces.afterKeywordBeforeParen = true
+continuationIndent.defnSite = 2
+continuationIndent.callSite = 2
+importSelectors = noBinPack
+
+newlines {
+  sometimesBeforeColonInMethodReturnType = false
+}
+
+align {
+  arrowEnumeratorGenerator = false
+  ifWhileOpenParen = false
+  openParenCallSite = false
+  openParenDefnSite = false
+}
+
+rewrite {
+  rules = [
+    AsciiSortImports,
+    RedundantBraces,
+    RedundantParens,
+    PreferCurlyFors
+  ]
+  redundantBraces.maxLines = 1
+}

--- a/build.sbt
+++ b/build.sbt
@@ -11,18 +11,18 @@
  * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
  */
 
-lazy val root = project.in(file("."))
+lazy val root = project
+  .in(file("."))
   .settings(
-    organization       :=  "com.snowplowanalytics",
-    name               :=  "scala-maxmind-iplookups",
-    version            :=  "0.4.0",
-    description        :=  "Scala wrapper for MaxMind GeoIP2 library",
-    scalaVersion       :=  "2.11.12",
-    crossScalaVersions :=  Seq("2.11.12", "2.12.5"),
-    scalacOptions      :=  BuildSettings.compilerOptions,
-    javacOptions       :=  BuildSettings.javaCompilerOptions,
-
-    scalafmtOnCompile  := true
+    organization := "com.snowplowanalytics",
+    name := "scala-maxmind-iplookups",
+    version := "0.4.0",
+    description := "Scala wrapper for MaxMind GeoIP2 library",
+    scalaVersion := "2.11.12",
+    crossScalaVersions := Seq("2.11.12", "2.12.5"),
+    scalacOptions := BuildSettings.compilerOptions,
+    javacOptions := BuildSettings.javaCompilerOptions,
+    scalafmtOnCompile := true
   )
   .settings(BuildSettings.publishSettings)
   .settings(

--- a/build.sbt
+++ b/build.sbt
@@ -20,7 +20,9 @@ lazy val root = project.in(file("."))
     scalaVersion       :=  "2.11.12",
     crossScalaVersions :=  Seq("2.11.12", "2.12.5"),
     scalacOptions      :=  BuildSettings.compilerOptions,
-    javacOptions       :=  BuildSettings.javaCompilerOptions
+    javacOptions       :=  BuildSettings.javaCompilerOptions,
+
+    scalafmtOnCompile  := true
   )
   .settings(BuildSettings.publishSettings)
   .settings(

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,2 @@
 addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.3")
+addSbtPlugin("com.lucidchart" % "sbt-scalafmt" % "1.15")

--- a/src/main/scala/com.snowplowanalytics.maxmind.iplookups/IpLookups.scala
+++ b/src/main/scala/com.snowplowanalytics.maxmind.iplookups/IpLookups.scala
@@ -26,22 +26,22 @@ import model._
 object IpLookups {
 
   /**
-    * Alternative constructor taking Strings rather than Files
-    *
-    * @param geoFile Geographic lookup database filepath
-    * @param ispFile ISP lookup database filepath
-    * @param domainFile Domain lookup database filepath
-    * @param connectionTypeFile Connection type lookup database filepath
-    * @param memCache Whether to use MaxMind's CHMCache
-    * @param lruCache Maximum size of SynchronizedLruMap cache
-    */
+   * Alternative constructor taking Strings rather than Files
+   *
+   * @param geoFile Geographic lookup database filepath
+   * @param ispFile ISP lookup database filepath
+   * @param domainFile Domain lookup database filepath
+   * @param connectionTypeFile Connection type lookup database filepath
+   * @param memCache Whether to use MaxMind's CHMCache
+   * @param lruCache Maximum size of SynchronizedLruMap cache
+   */
   def apply(
-      geoFile: Option[String] = None,
-      ispFile: Option[String] = None,
-      domainFile: Option[String] = None,
-      connectionTypeFile: Option[String] = None,
-      memCache: Boolean = true,
-      lruCache: Int = 10000
+    geoFile: Option[String] = None,
+    ispFile: Option[String] = None,
+    domainFile: Option[String] = None,
+    connectionTypeFile: Option[String] = None,
+    memCache: Boolean = true,
+    lruCache: Int = 10000
   ): IpLookups =
     new IpLookups(
       geoFile.map(new File(_)),
@@ -54,32 +54,32 @@ object IpLookups {
 }
 
 /**
-  * IpLookups is a Scala wrapper around MaxMind's own DatabaseReader Java class.
-  *
-  * Two main differences:
-  *
-  * 1. getLocation(ipS: String) now returns an IpLocation
-  *    case class, not a raw MaxMind Location
-  * 2. IpLookups introduces an LRU cache to improve
-  *    lookup performance
-  *
-  * Inspired by:
-  * https://github.com/jt6211/hadoop-dns-mining/blob/master/src/main/java/io/covert/dns/geo/IpLookups.java
-  *
-  * @param geoFile Geographic lookup database file
-  * @param ispFile ISP lookup database file
-  * @param domainFile Domain lookup database file
-  * @param connectionTypeFile Connection type lookup database file
-  * @param memCache Whether to use MaxMind's CHMCache
-  * @param lruCache Maximum size of SynchronizedLruMap cache
-  */
+ * IpLookups is a Scala wrapper around MaxMind's own DatabaseReader Java class.
+ *
+ * Two main differences:
+ *
+ * 1. getLocation(ipS: String) now returns an IpLocation
+ *    case class, not a raw MaxMind Location
+ * 2. IpLookups introduces an LRU cache to improve
+ *    lookup performance
+ *
+ * Inspired by:
+ * https://github.com/jt6211/hadoop-dns-mining/blob/master/src/main/java/io/covert/dns/geo/IpLookups.java
+ *
+ * @param geoFile Geographic lookup database file
+ * @param ispFile ISP lookup database file
+ * @param domainFile Domain lookup database file
+ * @param connectionTypeFile Connection type lookup database file
+ * @param memCache Whether to use MaxMind's CHMCache
+ * @param lruCache Maximum size of SynchronizedLruMap cache
+ */
 class IpLookups(
-    geoFile: Option[File] = None,
-    ispFile: Option[File] = None,
-    domainFile: Option[File] = None,
-    connectionTypeFile: Option[File] = None,
-    memCache: Boolean = true,
-    lruCache: Int = 10000
+  geoFile: Option[File] = None,
+  ispFile: Option[File] = None,
+  domainFile: Option[File] = None,
+  connectionTypeFile: Option[File] = None,
+  memCache: Boolean = true,
+  lruCache: Int = 10000
 ) {
 
   // Initialise the cache
@@ -97,15 +97,14 @@ class IpLookups(
   private val domainService =
     getService(domainFile).map(SpecializedReader(_, ReaderFunctions.domain))
   private val connectionTypeService =
-    getService(connectionTypeFile).map(
-      SpecializedReader(_, ReaderFunctions.connectionType))
+    getService(connectionTypeFile).map(SpecializedReader(_, ReaderFunctions.connectionType))
 
   /**
-    * Get a LookupService from a database file
-    *
-    * @param serviceFile The database file
-    * @return LookupService
-    */
+   * Get a LookupService from a database file
+   *
+   * @param serviceFile The database file
+   * @return LookupService
+   */
   private def getService(serviceFile: Option[File]): Option[DatabaseReader] =
     serviceFile.map { f =>
       val builder = new DatabaseReader.Builder(f)
@@ -116,40 +115,39 @@ class IpLookups(
     }
 
   /**
-    * Returns the MaxMind location for this IP address
-    * as an IpLocation, or None if MaxMind cannot find
-    * the location.
-    */
+   * Returns the MaxMind location for this IP address
+   * as an IpLocation, or None if MaxMind cannot find
+   * the location.
+   */
   val performLookups: String => IpLookupResult = (s: String) =>
     lru
       .map(performLookupsWithLruCache(_, s))
       .getOrElse(performLookupsWithoutLruCache(s))
 
   /**
-    * This version does not use the LRU cache.
-    * Concurrently looks up information
-    * based on an IP address from one or
-    * more MaxMind LookupServices
-    *
-    * @param ip IP address
-    * @return Tuple containing the results of the
-    *         LookupServices
-    */
+   * This version does not use the LRU cache.
+   * Concurrently looks up information
+   * based on an IP address from one or
+   * more MaxMind LookupServices
+   *
+   * @param ip IP address
+   * @return Tuple containing the results of the
+   *         LookupServices
+   */
   private def performLookupsWithoutLruCache(ip: String): IpLookupResult = {
 
     val ipAddress = getIpAddress(ip)
 
     /**
-      * Creates a Validation boxing the result of using a lookup service on the ip
-      * @param service ISP, domain or connection type LookupService
-      * @return the result of the lookup
-      */
-    def getLookup(service: Option[SpecializedReader])
-      : Option[Validation[Throwable, String]] =
+     * Creates a Validation boxing the result of using a lookup service on the ip
+     * @param service ISP, domain or connection type LookupService
+     * @return the result of the lookup
+     */
+    def getLookup(service: Option[SpecializedReader]): Option[Validation[Throwable, String]] =
       service.map { s =>
         for {
           ipA <- ipAddress
-          v <- s.getValue(ipA)
+          v   <- s.getValue(ipA)
         } yield v
       }
 
@@ -157,7 +155,7 @@ class IpLookups(
       geoService.map { gs =>
         for {
           ipA <- ipAddress
-          v <- Validation.fromTryCatch(gs.city(ipA))
+          v   <- Validation.fromTryCatch(gs.city(ipA))
         } yield IpLocation.apply(v)
       }
 
@@ -171,19 +169,19 @@ class IpLookups(
   }
 
   /**
-    * Returns the MaxMind location for this IP address
-    * as an IpLocation, or None if MaxMind cannot find
-    * the location.
-    *
-    * This version uses and maintains the LRU cache.
-    *
-    * Don't confuse the LRU returning None (meaning that no
-    * cache entry could be found), versus an extant cache entry
-    * containing None (meaning that the IP address is unknown).
-    */
+   * Returns the MaxMind location for this IP address
+   * as an IpLocation, or None if MaxMind cannot find
+   * the location.
+   *
+   * This version uses and maintains the LRU cache.
+   *
+   * Don't confuse the LRU returning None (meaning that no
+   * cache entry could be found), versus an extant cache entry
+   * containing None (meaning that the IP address is unknown).
+   */
   private def performLookupsWithLruCache(
-      lru: SynchronizedLruMap[String, IpLookupResult],
-      ip: String
+    lru: SynchronizedLruMap[String, IpLookupResult],
+    ip: String
   ): IpLookupResult = lru.get(ip) match {
     case Some(result) => result // In the LRU cache
     case None => // Not in the LRU cache

--- a/src/main/scala/com.snowplowanalytics.maxmind.iplookups/SpecializedReader.scala
+++ b/src/main/scala/com.snowplowanalytics.maxmind.iplookups/SpecializedReader.scala
@@ -26,8 +26,8 @@ final case class SpecializedReader(db: DatabaseReader, f: ReaderFunction) {
 object ReaderFunctions {
   type ReaderFunction = (DatabaseReader, InetAddress) => String
 
-  val isp = (db: DatabaseReader, ip: InetAddress) => db.isp(ip).getIsp
-  val org = (db: DatabaseReader, ip: InetAddress) => db.isp(ip).getOrganization
+  val isp    = (db: DatabaseReader, ip: InetAddress) => db.isp(ip).getIsp
+  val org    = (db: DatabaseReader, ip: InetAddress) => db.isp(ip).getOrganization
   val domain = (db: DatabaseReader, ip: InetAddress) => db.domain(ip).getDomain
   val connectionType = (db: DatabaseReader, ip: InetAddress) =>
     db.connectionType(ip).getConnectionType.toString

--- a/src/main/scala/com.snowplowanalytics.maxmind.iplookups/model.scala
+++ b/src/main/scala/com.snowplowanalytics.maxmind.iplookups/model.scala
@@ -19,33 +19,38 @@ object model {
 
   /** A case class wrapper around the MaxMind CityResponse class. */
   final case class IpLocation(
-    countryCode: String,
-    countryName: String,
-    region: Option[String],
-    city: Option[String],
-    latitude: Float,
-    longitude: Float,
-    timezone: Option[String],
-    postalCode: Option[String],
-    metroCode: Option[Int],
-    regionName: Option[String]
+      countryCode: String,
+      countryName: String,
+      region: Option[String],
+      city: Option[String],
+      latitude: Float,
+      longitude: Float,
+      timezone: Option[String],
+      postalCode: Option[String],
+      metroCode: Option[Int],
+      regionName: Option[String]
   )
 
   /** Companion class contains a constructor which takes a MaxMind CityResponse. */
   object IpLocation {
+
     /**
-    * Constructs an IpLocation instance from a MaxMind CityResponse instance.
-    * @param cityResponse MaxMind CityResponse object
-    * @return IpLocation
-    */
+      * Constructs an IpLocation instance from a MaxMind CityResponse instance.
+      * @param cityResponse MaxMind CityResponse object
+      * @return IpLocation
+      */
     def apply(cityResponse: CityResponse): IpLocation =
       IpLocation(
         countryCode = cityResponse.getCountry.getIsoCode,
         countryName = cityResponse.getCountry.getName,
         region = Option(cityResponse.getMostSpecificSubdivision.getIsoCode),
         city = Option(cityResponse.getCity.getName),
-        latitude = Option(cityResponse.getLocation.getLatitude).map(_.toFloat).getOrElse(0F),
-        longitude = Option(cityResponse.getLocation.getLongitude).map(_.toFloat).getOrElse(0F),
+        latitude = Option(cityResponse.getLocation.getLatitude)
+          .map(_.toFloat)
+          .getOrElse(0F),
+        longitude = Option(cityResponse.getLocation.getLongitude)
+          .map(_.toFloat)
+          .getOrElse(0F),
         timezone = Option(cityResponse.getLocation.getTimeZone),
         postalCode = Option(cityResponse.getPostal.getCode),
         metroCode = Option(cityResponse.getLocation.getMetroCode).map(_.toInt),
@@ -55,10 +60,10 @@ object model {
 
   /** Result of MaxMind lookups */
   final case class IpLookupResult(
-    ipLocation: Option[Validation[Throwable, IpLocation]],
-    isp: Option[Validation[Throwable, String]],
-    organization: Option[Validation[Throwable, String]],
-    domain: Option[Validation[Throwable, String]],
-    connectionType: Option[Validation[Throwable, String]]
+      ipLocation: Option[Validation[Throwable, IpLocation]],
+      isp: Option[Validation[Throwable, String]],
+      organization: Option[Validation[Throwable, String]],
+      domain: Option[Validation[Throwable, String]],
+      connectionType: Option[Validation[Throwable, String]]
   )
 }

--- a/src/main/scala/com.snowplowanalytics.maxmind.iplookups/model.scala
+++ b/src/main/scala/com.snowplowanalytics.maxmind.iplookups/model.scala
@@ -19,26 +19,26 @@ object model {
 
   /** A case class wrapper around the MaxMind CityResponse class. */
   final case class IpLocation(
-      countryCode: String,
-      countryName: String,
-      region: Option[String],
-      city: Option[String],
-      latitude: Float,
-      longitude: Float,
-      timezone: Option[String],
-      postalCode: Option[String],
-      metroCode: Option[Int],
-      regionName: Option[String]
+    countryCode: String,
+    countryName: String,
+    region: Option[String],
+    city: Option[String],
+    latitude: Float,
+    longitude: Float,
+    timezone: Option[String],
+    postalCode: Option[String],
+    metroCode: Option[Int],
+    regionName: Option[String]
   )
 
   /** Companion class contains a constructor which takes a MaxMind CityResponse. */
   object IpLocation {
 
     /**
-      * Constructs an IpLocation instance from a MaxMind CityResponse instance.
-      * @param cityResponse MaxMind CityResponse object
-      * @return IpLocation
-      */
+     * Constructs an IpLocation instance from a MaxMind CityResponse instance.
+     * @param cityResponse MaxMind CityResponse object
+     * @return IpLocation
+     */
     def apply(cityResponse: CityResponse): IpLocation =
       IpLocation(
         countryCode = cityResponse.getCountry.getIsoCode,
@@ -60,10 +60,10 @@ object model {
 
   /** Result of MaxMind lookups */
   final case class IpLookupResult(
-      ipLocation: Option[Validation[Throwable, IpLocation]],
-      isp: Option[Validation[Throwable, String]],
-      organization: Option[Validation[Throwable, String]],
-      domain: Option[Validation[Throwable, String]],
-      connectionType: Option[Validation[Throwable, String]]
+    ipLocation: Option[Validation[Throwable, IpLocation]],
+    isp: Option[Validation[Throwable, String]],
+    organization: Option[Validation[Throwable, String]],
+    domain: Option[Validation[Throwable, String]],
+    connectionType: Option[Validation[Throwable, String]]
   )
 }

--- a/src/test/scala/com.snowplowanalytics.maxmind.iplookups/IpLookupsTest.scala
+++ b/src/test/scala/com.snowplowanalytics.maxmind.iplookups/IpLookupsTest.scala
@@ -24,13 +24,18 @@ import model._
 object IpLookupsTest {
 
   def ipLookupsFromFiles(memCache: Boolean, lruCache: Int): IpLookups = {
-    val geoFile    = getClass.getResource("GeoIP2-City-Test.mmdb").getFile
-    val ispFile    = getClass.getResource("GeoIP2-ISP-Test.mmdb").getFile
+    val geoFile = getClass.getResource("GeoIP2-City-Test.mmdb").getFile
+    val ispFile = getClass.getResource("GeoIP2-ISP-Test.mmdb").getFile
     val domainFile = getClass.getResource("GeoIP2-Domain-Test.mmdb").getFile
-    val connectionTypeFile = getClass.getResource("GeoIP2-Connection-Type-Test.mmdb").getFile
+    val connectionTypeFile =
+      getClass.getResource("GeoIP2-Connection-Type-Test.mmdb").getFile
 
-    IpLookups(Some(geoFile), Some(ispFile), Some(domainFile), Some(connectionTypeFile),
-      memCache, lruCache)
+    IpLookups(Some(geoFile),
+              Some(ispFile),
+              Some(domainFile),
+              Some(connectionTypeFile),
+              memCache,
+              lruCache)
   }
 
   // Databases and test data taken from https://github.com/maxmind/MaxMind-DB/tree/master/test-data
@@ -48,12 +53,14 @@ object IpLookupsTest {
         metroCode = None,
         regionName = Some("Jilin Sheng")
       ).success.some,
-      new AddressNotFoundException("The address 175.16.199.0 is not in the database.").failure.some,
-      new AddressNotFoundException("The address 175.16.199.0 is not in the database.").failure.some,
-      new AddressNotFoundException("The address 175.16.199.0 is not in the database.").failure.some,
+      new AddressNotFoundException(
+        "The address 175.16.199.0 is not in the database.").failure.some,
+      new AddressNotFoundException(
+        "The address 175.16.199.0 is not in the database.").failure.some,
+      new AddressNotFoundException(
+        "The address 175.16.199.0 is not in the database.").failure.some,
       "Dialup".success.some
     ),
-
     "216.160.83.56" -> IpLookupResult(
       IpLocation(
         countryCode = "US",
@@ -69,10 +76,11 @@ object IpLookupsTest {
       ).success.some,
       "Century Link".success.some,
       "Lariat Software".success.some,
-      new AddressNotFoundException("The address 216.160.83.56 is not in the database.").failure.some,
-      new AddressNotFoundException("The address 216.160.83.56 is not in the database.").failure.some
+      new AddressNotFoundException(
+        "The address 216.160.83.56 is not in the database.").failure.some,
+      new AddressNotFoundException(
+        "The address 216.160.83.56 is not in the database.").failure.some
     ),
-
     "67.43.156.0" -> IpLookupResult(
       IpLocation(
         countryCode = "BT",
@@ -89,17 +97,22 @@ object IpLookupsTest {
       "Loud Packet".success.some,
       "zudoarichikito_".success.some,
       "shoesfin.NET".success.some,
-      new AddressNotFoundException("The address 67.43.156.0 is not in the database.").failure.some
+      new AddressNotFoundException(
+        "The address 67.43.156.0 is not in the database.").failure.some
     ),
-
     // Invalid IP address, as per
     // http://stackoverflow.com/questions/10456044/what-is-a-good-invalid-ip-address-to-use-for-unit-tests
     "192.0.2.0" -> IpLookupResult(
-      new AddressNotFoundException("The address 192.0.2.0 is not in the database.").failure.some,
-      new AddressNotFoundException("The address 192.0.2.0 is not in the database.").failure.some,
-      new AddressNotFoundException("The address 192.0.2.0 is not in the database.").failure.some,
-      new AddressNotFoundException("The address 192.0.2.0 is not in the database.").failure.some,
-      new AddressNotFoundException("The address 192.0.2.0 is not in the database.").failure.some
+      new AddressNotFoundException(
+        "The address 192.0.2.0 is not in the database.").failure.some,
+      new AddressNotFoundException(
+        "The address 192.0.2.0 is not in the database.").failure.some,
+      new AddressNotFoundException(
+        "The address 192.0.2.0 is not in the database.").failure.some,
+      new AddressNotFoundException(
+        "The address 192.0.2.0 is not in the database.").failure.some,
+      new AddressNotFoundException(
+        "The address 192.0.2.0 is not in the database.").failure.some
     )
   )
 }
@@ -109,9 +122,14 @@ class IpLookupsTest extends Specification {
   "Looking up some IP address locations should match their expected locations" should {
 
     val mcf: Boolean => String = mc => if (mc) "using" else "without using"
-    val lcf: Int => String = lc => if (lc > 0) "LRU cache sized %s".format(lc) else "no LRU cache"
+    val lcf: Int => String =
+      lc => if (lc > 0) "LRU cache sized %s".format(lc) else "no LRU cache"
     val formatter: (String, Boolean, Int) => String =
-      (ip, mcache, lcache) => "The IP address %s looked up (%s memory cache and with %s)".format(ip, mcf(mcache), lcf(lcache))
+      (ip, mcache, lcache) =>
+        "The IP address %s looked up (%s memory cache and with %s)".format(
+          ip,
+          mcf(mcache),
+          lcf(lcache))
 
     import IpLookupsTest._
     for (memCache <- Seq(true, false);
@@ -119,11 +137,12 @@ class IpLookupsTest extends Specification {
 
       val ipLookups = ipLookupsFromFiles(memCache, lruCache)
 
-      testData foreach { case (ip, expected) =>
-        formatter(ip, memCache, lruCache) should {
-          val actual = ipLookups.performLookups(ip)
-          matchIpLookupResult(actual, expected)
-        }
+      testData foreach {
+        case (ip, expected) =>
+          formatter(ip, memCache, lruCache) should {
+            val actual = ipLookups.performLookups(ip)
+            matchIpLookupResult(actual, expected)
+          }
       }
     }
 
@@ -148,7 +167,8 @@ class IpLookupsTest extends Specification {
     }
   }
 
-  private def matchIpLookupResult(actual: IpLookupResult, expected: IpLookupResult) = {
+  private def matchIpLookupResult(actual: IpLookupResult,
+                                  expected: IpLookupResult) = {
     s"have iplocation = ${actual.ipLocation}" in {
       matchThrowables(actual.ipLocation, expected.ipLocation)
     }
@@ -156,7 +176,9 @@ class IpLookupsTest extends Specification {
     s"have org = ${actual.organization}" in {
       matchThrowables(actual.organization, expected.organization)
     }
-    s"have domain = ${actual.domain}" in { matchThrowables(actual.domain, expected.domain) }
+    s"have domain = ${actual.domain}" in {
+      matchThrowables(actual.domain, expected.domain)
+    }
     s"have net speed = ${actual.connectionType}" in {
       matchThrowables(actual.connectionType, expected.connectionType)
     }
@@ -164,14 +186,16 @@ class IpLookupsTest extends Specification {
 
   // needed because == doesn't work on exceptions
   private def matchThrowables[A](
-    actual: Option[Validation[Throwable, A]],
-    expected: Option[Validation[Throwable, A]]
+      actual: Option[Validation[Throwable, A]],
+      expected: Option[Validation[Throwable, A]]
   ): Boolean = actual match {
     case None => actual must_== expected
-    case Some(r) => r match {
-      case Success(_) => actual must_== expected
-      case Failure(_) => getErrorMessage(actual) must_== getErrorMessage(expected)
-    }
+    case Some(r) =>
+      r match {
+        case Success(_) => actual must_== expected
+        case Failure(_) =>
+          getErrorMessage(actual) must_== getErrorMessage(expected)
+      }
   }
 
   private def getErrorMessage[A](


### PR DESCRIPTION
Uses an sbt plugin to automatically reformat code according to default scalafmt rules before each compile.

Close #66