### PR TITLE
Dependency bumps

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -16,7 +16,7 @@ object Dependencies {
   val cats             = "org.typelevel"         %% "cats-core"                  % "2.7.0"
   val catsEffect       = "org.typelevel"         %% "cats-effect"                % "3.3.5"
   val lruMap           = "com.snowplowanalytics" %% "scala-lru-map"              % "0.6.0"
-  val maxmind          = "com.maxmind.geoip2"    %  "geoip2"                     % "3.0.0"
+  val maxmind          = "com.maxmind.geoip2"    %  "geoip2"                     % "3.0.1"
   val specs2           = "org.specs2"            %% "specs2-core"                % "4.13.2" % Test
   val specs2CatsEffect = "org.typelevel"         %% "cats-effect-testing-specs2" % "1.4.0"  % Test
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -13,7 +13,7 @@
 import sbt._
 
 object Dependencies {
-  val cats             = "org.typelevel"         %% "cats-core"                  % "2.7.0"
+  val cats             = "org.typelevel"         %% "cats-core"                  % "2.8.0"
   val catsEffect       = "org.typelevel"         %% "cats-effect"                % "3.3.5"
   val lruMap           = "com.snowplowanalytics" %% "scala-lru-map"              % "0.6.0"
   val maxmind          = "com.maxmind.geoip2"    %  "geoip2"                     % "3.0.1"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -17,6 +17,6 @@ object Dependencies {
   val catsEffect       = "org.typelevel"         %% "cats-effect"                % "3.3.5"
   val lruMap           = "com.snowplowanalytics" %% "scala-lru-map"              % "0.6.0"
   val maxmind          = "com.maxmind.geoip2"    %  "geoip2"                     % "3.0.1"
-  val specs2           = "org.specs2"            %% "specs2-core"                % "4.13.2" % Test
+  val specs2           = "org.specs2"            %% "specs2-core"                % "4.15.0" % Test
   val specs2CatsEffect = "org.typelevel"         %% "cats-effect-testing-specs2" % "1.4.0"  % Test
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -14,7 +14,7 @@ import sbt._
 
 object Dependencies {
   val cats             = "org.typelevel"         %% "cats-core"                  % "2.8.0"
-  val catsEffect       = "org.typelevel"         %% "cats-effect"                % "3.3.5"
+  val catsEffect       = "org.typelevel"         %% "cats-effect"                % "3.3.14"
   val lruMap           = "com.snowplowanalytics" %% "scala-lru-map"              % "0.6.0"
   val maxmind          = "com.maxmind.geoip2"    %  "geoip2"                     % "3.0.1"
   val specs2           = "org.specs2"            %% "specs2-core"                % "4.15.0" % Test


### PR DESCRIPTION
Before bump:

```
snyk test
```

> ✗ Denial of Service (DoS) [High Severity][https://security.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-2421244] in com.fasterxml.jackson.core:jackson-databind@2.13.1
  introduced by com.fasterxml.jackson.core:jackson-annotations@2.13.1 > com.fasterxml.jackson.core:jackson-databind@2.13.1
>  This issue was fixed in versions: 2.12.6.1, 2.13.2.1

After bump:

```
snyk test
```

> ✔ Tested 15 dependencies for known issues, no vulnerable paths found.