### PR TITLE
Scala 3 cross-compilation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,34 @@
 target/
+
+# macOS
+.DS_Store
+
+# sbt specific
+dist/*
+target/
+lib_managed/
+src_managed/
+project/boot/
+project/plugins/project/
+project/local-plugins.sbt
+.history
+.ensime
+.ensime_cache/
+.sbt-scripted/
+local.sbt
+
+# Bloop
+.bsp
+
+# VS Code
+.vscode/
+
+# Metals
+.bloop/
+.metals/
+metals.sbt
+
+# IDEA
+.idea
+.idea_modules
+/.worksheet/

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,7 +1,11 @@
+version = "3.6.1"
+runner.dialect = scala3
 style = defaultWithAlign
 maxColumn = 100
 
-docstrings = JavaDoc
+docstrings.style = Asterisk
+docstrings.wrap = no
+
 optIn.breakChainOnFirstMethodDot = true
 spaces.afterKeywordBeforeParen = true
 continuationIndent.defnSite = 2
@@ -28,3 +32,4 @@ rewrite {
   ]
   redundantBraces.maxLines = 1
 }
+

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ can also configure an LRU (Least Recently Used) cache of variable size
 
 ## Installation
 
-The latest version of scala-maxmind-iplookups is **0.8.1** and is compatible with Scala 3.2, 2.13, and 2.12.
+The latest version of scala-maxmind-iplookups is **0.8.1** and is compatible with Scala 3, 2.13, and 2.12.
 
 Add this to your SBT config:
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ can also configure an LRU (Least Recently Used) cache of variable size
 
 ## Installation
 
-The latest version of scala-maxmind-iplookups is **0.8.1** and is compatible with Scala 2.13.
+The latest version of scala-maxmind-iplookups is **0.8.1** and is compatible with Scala 3.2, 2.13, and 2.12.
 
 Add this to your SBT config:
 

--- a/build.sbt
+++ b/build.sbt
@@ -18,8 +18,8 @@ lazy val root = project
     organization := "com.snowplowanalytics",
     name := "scala-maxmind-iplookups",
     description := "Scala wrapper for MaxMind GeoIP2 library",
-    scalaVersion := "2.13.8",
-    crossScalaVersions := Seq("2.13.8", "2.12.15"),
+    scalaVersion := "3.2.2",
+    crossScalaVersions := Seq("3.2.2", "2.13.10", "2.12.17"),
     javacOptions := BuildSettings.javaCompilerOptions,
     scalafmtOnCompile := true
   )

--- a/build.sbt
+++ b/build.sbt
@@ -18,8 +18,8 @@ lazy val root = project
     organization := "com.snowplowanalytics",
     name := "scala-maxmind-iplookups",
     description := "Scala wrapper for MaxMind GeoIP2 library",
-    scalaVersion := "3.2.2",
-    crossScalaVersions := Seq("3.2.2", "2.13.10", "2.12.17"),
+    scalaVersion := "3.3.0",
+    crossScalaVersions := Seq("3.3.0", "2.13.10", "2.12.17"),
     javacOptions := BuildSettings.javaCompilerOptions,
     scalafmtOnCompile := true
   )

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -15,8 +15,8 @@ import sbt._
 object Dependencies {
   val cats             = "org.typelevel"         %% "cats-core"                  % "2.8.0"
   val catsEffect       = "org.typelevel"         %% "cats-effect"                % "3.3.14"
-  val lruMap           = "com.snowplowanalytics" %% "scala-lru-map"              % "0.6.0"
+  val lruMap           = "com.snowplowanalytics" %% "scala-lru-map"              % "0.6.1"
   val maxmind          = "com.maxmind.geoip2"    %  "geoip2"                     % "3.0.1"
   val specs2           = "org.specs2"            %% "specs2-core"                % "4.15.0" % Test
-  val specs2CatsEffect = "org.typelevel"         %% "cats-effect-testing-specs2" % "1.4.0"  % Test
+  val specs2CatsEffect = "org.typelevel"         %% "cats-effect-testing-specs2" % "1.5.0"  % Test
 }

--- a/src/test/scala/com.snowplowanalytics.maxmind.iplookups/IpLookupsTest.scala
+++ b/src/test/scala/com.snowplowanalytics.maxmind.iplookups/IpLookupsTest.scala
@@ -233,12 +233,14 @@ class IpLookupsTest extends Specification with Tables with CatsEffect {
     ip: String,
     expected: IpLookupResult
   ) = {
+    import cats.syntax.all._
     ipLookupsFromFiles[F](memCache, lruCache)
       .flatMap(_.performLookups(ip))
       .map(r => matchIpLookupResult(r, expected))
   }
 
   private def assertNoneWithoutFiles[F[_]: CreateIpLookups: Monad] = {
+    import cats.syntax.all._
     val noFilesLookup = CreateIpLookups[F].createFromFiles(
       None,
       None,


### PR DESCRIPTION
Continued the work from https://github.com/snowplow/scala-maxmind-iplookups/pull/178 with a couple of version bumps and a test compilation fix (conflict between cats and specs2 extension methods), everything seems to work.