### PR TITLE
Extract ASN fields from ISP database

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ final case class IpLookupResult(
   ipLocation: Option[Either[Throwable, IpLocation]],
   isp: Option[Either[Throwable, String]],
   organization: Option[Either[Throwable, String]],
+  asn: Option[Either[Throwable, Asn]],
   domain: Option[Either[Throwable, String]],
   connectionType: Option[Either[Throwable, String]]
 )
@@ -150,11 +151,12 @@ final case class IpLookupResult(
 
 The first element is the result of the geographic location lookup. It is either `None` (if no
 geographic lookup database was provided) or `Some(ipLocation)`, where `ipLocation` is an instance of
-the `IpLocation` case class described below. The other three elements in the tuple are `Option`s
-wrapping the results of the other four possible lookups: ISP, organization, domain, and connection
-type.
+the `IpLocation` case class described below. The other elements are `Option`s wrapping the results
+of the other possible lookups: ISP, organization, ASN, domain, and connection type.
 
-Note that enabling providing an ISP database will return an `organization` in addition to an `isp`.
+Note that providing an ISP database will return `organization` and `asn` in addition to `isp`.
+The `asn` field contains an `Asn` case class with `autonomousSystemNumber` and
+`autonomousSystemOrganization` information extracted from the ISP database.
 
 ### IpLocation case class
 
@@ -175,6 +177,18 @@ final case class IpLocation(
   isInEuropeanUnion: Boolean,
   continent: String,
   accuracyRadius: Int
+)
+```
+
+### Asn case class
+
+The ASN lookup (extracted from the ISP database) returns an `Asn` case class instance with the
+following structure:
+
+```scala
+final case class Asn(
+  autonomousSystemNumber: Option[Long],
+  autonomousSystemOrganization: Option[String]
 )
 ```
 
@@ -206,6 +220,10 @@ println(lookupResult.isp) // => Some(Right("FDN Communications"))
 
 // Organization lookup
 println(lookupResult.organization) // => Some(Right("DSLAM WAN Allocation"))
+
+// ASN lookup
+println(lookupResult.asn.map(_.autonomousSystemNumber)) // => Some(Right(Some(123)))
+println(lookupResult.asn.map(_.autonomousSystemOrganization)) // => Some(Right(Some("Example ISP")))
 
 // Domain lookup
 println(lookupResult.domain) // => Some(Right("nuvox.net"))

--- a/src/main/scala/com.snowplowanalytics.maxmind.iplookups/IpLookups.scala
+++ b/src/main/scala/com.snowplowanalytics.maxmind.iplookups/IpLookups.scala
@@ -204,8 +204,7 @@ class IpLookups[F[_]: Monad] private[iplookups] (
 )(implicit SR: SpecializedReader[F], IAR: IpAddressResolver[F]) {
   // Configure the lookup services
   private val geoService    = getService(geoFile)
-  private val ispService    = getService(ispFile).map((_, ReaderFunctions.isp))
-  private val orgService    = getService(ispFile).map((_, ReaderFunctions.org))
+  private val ispService    = getService(ispFile)
   private val domainService = getService(domainFile).map((_, ReaderFunctions.domain))
   private val connectionTypeService =
     getService(connectionTypeFile).map((_, ReaderFunctions.connectionType))
@@ -235,7 +234,7 @@ class IpLookups[F[_]: Monad] private[iplookups] (
    */
   private def getLookup(
     ipAddress: Either[Throwable, InetAddress],
-    service: Option[(DatabaseReader, ReaderFunction)]
+    service: Option[(DatabaseReader, ReaderFunction[String])]
   ): F[Option[Either[Throwable, String]]] =
     (ipAddress, service) match {
       case (Right(ipA), Some((db, f))) =>
@@ -260,7 +259,7 @@ class IpLookups[F[_]: Monad] private[iplookups] (
     ipAddress: Either[Throwable, InetAddress]
   ): F[Option[Either[Throwable, IpLocation]]] = (ipAddress, geoService) match {
     case (Right(ipA), Some(gs)) =>
-      SR.getCityValue(gs, ipA)
+      SR.getValue(ReaderFunctions.city, gs, ipA)
         .map(loc => loc.map(IpLocation(_)).some)
     case (Left(f), _) => Monad[F].pure(Some(Left(f)))
     case _            => Monad[F].pure(None)
@@ -270,8 +269,18 @@ class IpLookups[F[_]: Monad] private[iplookups] (
     ipAddress: Either[Throwable, InetAddress]
   ): F[Option[Either[Throwable, AnonymousIp]]] = (ipAddress, anonymousService) match {
     case (Right(ipA), Some(gs)) =>
-      SR.getAnonymousValue(gs, ipA)
+      SR.getValue(ReaderFunctions.anonymousIp, gs, ipA)
         .map(loc => loc.map(AnonymousIp(_)).some)
+    case (Left(f), _) => Monad[F].pure(Some(Left(f)))
+    case _            => Monad[F].pure(None)
+  }
+
+  private def getIspLookup(
+    ipAddress: Either[Throwable, InetAddress]
+  ): F[Option[Either[Throwable, Isp]]] = (ipAddress, ispService) match {
+    case (Right(ipA), Some(gs)) =>
+      SR.getValue(ReaderFunctions.isp, gs, ipA)
+        .map(ispResponse => ispResponse.map(Isp(_)).some)
     case (Left(f), _) => Monad[F].pure(Some(Left(f)))
     case _            => Monad[F].pure(None)
   }
@@ -290,13 +299,15 @@ class IpLookups[F[_]: Monad] private[iplookups] (
     for {
       ipAddress <- IAR.resolve(ip)
 
-      ipLocation     <- getLocationLookup(ipAddress)
-      isp            <- getLookup(ipAddress, ispService)
-      org            <- getLookup(ipAddress, orgService)
+      ipLocation  <- getLocationLookup(ipAddress)
+      ispResponse <- getIspLookup(ipAddress)
+      ispName = ispResponse.map(_.map(_.name))
+      org     = ispResponse.map(_.map(_.organization))
+      asn     = ispResponse.map(_.map(_.asn))
       domain         <- getLookup(ipAddress, domainService)
       connectionType <- getLookup(ipAddress, connectionTypeService)
       anonymous      <- getAnonymousIpLookup(ipAddress)
-    } yield IpLookupResult(ipLocation, isp, org, domain, connectionType, anonymous)
+    } yield IpLookupResult(ipLocation, ispName, org, asn, domain, connectionType, anonymous)
 
   /**
    * Returns the MaxMind location for this IP address

--- a/src/main/scala/com.snowplowanalytics.maxmind.iplookups/SpecializedReader.scala
+++ b/src/main/scala/com.snowplowanalytics.maxmind.iplookups/SpecializedReader.scala
@@ -18,102 +18,52 @@ import cats.{Eval, Id}
 import cats.effect.Sync
 import cats.syntax.either._
 import com.maxmind.geoip2.DatabaseReader
-import com.maxmind.geoip2.model.CityResponse
-import com.maxmind.geoip2.model.AnonymousIpResponse
 
 import model._
 
 /** Data type letting you read data in maxmind's DatabaseReader. */
 sealed trait SpecializedReader[F[_]] {
-  def getValue(
-    f: ReaderFunction,
+  def getValue[A](
+    f: ReaderFunction[A],
     db: DatabaseReader,
     ip: InetAddress
-  ): F[Either[Throwable, String]]
-
-  def getCityValue(
-    db: DatabaseReader,
-    ip: InetAddress
-  ): F[Either[Throwable, CityResponse]]
-
-  def getAnonymousValue(
-    db: DatabaseReader,
-    ip: InetAddress
-  ): F[Either[Throwable, AnonymousIpResponse]]
-
+  ): F[Either[Throwable, A]]
 }
 
 object SpecializedReader {
   implicit def syncSpecializedReader[F[_]: Sync]: SpecializedReader[F] = new SpecializedReader[F] {
-    def getValue(
-      f: ReaderFunction,
+    def getValue[A](
+      f: ReaderFunction[A],
       db: DatabaseReader,
       ip: InetAddress
-    ): F[Either[Throwable, String]] =
+    ): F[Either[Throwable, A]] =
       Sync[F].delay(Either.catchNonFatal(f(db, ip)))
-
-    def getCityValue(
-      db: DatabaseReader,
-      ip: InetAddress
-    ): F[Either[Throwable, CityResponse]] =
-      Sync[F].delay(Either.catchNonFatal(db.city(ip)))
-
-    def getAnonymousValue(
-      db: DatabaseReader,
-      ip: InetAddress
-    ): F[Either[Throwable, AnonymousIpResponse]] =
-      Sync[F].delay(Either.catchNonFatal(db.anonymousIp(ip)))
-
   }
 
   implicit def evalSpecializedReader: SpecializedReader[Eval] = new SpecializedReader[Eval] {
-    def getValue(
-      f: ReaderFunction,
+    def getValue[A](
+      f: ReaderFunction[A],
       db: DatabaseReader,
       ip: InetAddress
-    ): Eval[Either[Throwable, String]] =
+    ): Eval[Either[Throwable, A]] =
       Eval.later(Either.catchNonFatal(f(db, ip)))
-
-    def getCityValue(
-      db: DatabaseReader,
-      ip: InetAddress
-    ): Eval[Either[Throwable, CityResponse]] =
-      Eval.later(Either.catchNonFatal(db.city(ip)))
-
-    def getAnonymousValue(
-      db: DatabaseReader,
-      ip: InetAddress
-    ): Eval[Either[Throwable, AnonymousIpResponse]] =
-      Eval.later(Either.catchNonFatal(db.anonymousIp(ip)))
-
   }
 
   implicit def idSpecializedReader: SpecializedReader[Id] = new SpecializedReader[Id] {
-    def getValue(
-      f: ReaderFunction,
+    def getValue[A](
+      f: ReaderFunction[A],
       db: DatabaseReader,
       ip: InetAddress
-    ): Id[Either[Throwable, String]] =
+    ): Id[Either[Throwable, A]] =
       Either.catchNonFatal(f(db, ip))
-
-    def getCityValue(
-      db: DatabaseReader,
-      ip: InetAddress
-    ): Id[Either[Throwable, CityResponse]] =
-      Either.catchNonFatal(db.city(ip))
-
-    def getAnonymousValue(
-      db: DatabaseReader,
-      ip: InetAddress
-    ): Id[Either[Throwable, AnonymousIpResponse]] =
-      Either.catchNonFatal(db.anonymousIp(ip))
   }
 }
 
 object ReaderFunctions {
-  val isp    = (db: DatabaseReader, ip: InetAddress) => db.isp(ip).getIsp
-  val org    = (db: DatabaseReader, ip: InetAddress) => db.isp(ip).getOrganization
+  val isp    = (db: DatabaseReader, ip: InetAddress) => db.isp(ip)
   val domain = (db: DatabaseReader, ip: InetAddress) => db.domain(ip).getDomain
   val connectionType = (db: DatabaseReader, ip: InetAddress) =>
     db.connectionType(ip).getConnectionType.toString
+  val city        = (db: DatabaseReader, ip: InetAddress) => db.city(ip)
+  val anonymousIp = (db: DatabaseReader, ip: InetAddress) => db.anonymousIp(ip)
 }

--- a/src/main/scala/com.snowplowanalytics.maxmind.iplookups/model.scala
+++ b/src/main/scala/com.snowplowanalytics.maxmind.iplookups/model.scala
@@ -22,11 +22,10 @@ import cats.instances.option._
 import cats.instances.either._
 
 import com.maxmind.geoip2.DatabaseReader
-import com.maxmind.geoip2.model.CityResponse
-import com.maxmind.geoip2.model.AnonymousIpResponse
+import com.maxmind.geoip2.model.{AnonymousIpResponse, AsnResponse, CityResponse, IspResponse}
 
 object model {
-  type ReaderFunction = (DatabaseReader, InetAddress) => String
+  type ReaderFunction[A] = (DatabaseReader, InetAddress) => A
 
   type Error[A] = Either[Throwable, A]
 
@@ -55,6 +54,19 @@ object model {
     isHostingProvider: Boolean,
     isPublicProxy: Boolean,
     isTorExitNode: Boolean
+  )
+
+  /** A case class wrapper around the MaxMind AsnResponse class. */
+  final case class Asn(
+    autonomousSystemNumber: Option[Long],
+    autonomousSystemOrganization: Option[String]
+  )
+
+  /** A case class wrapper around the MaxMind IspResponse class. */
+  final case class Isp(
+    name: String,
+    organization: String,
+    asn: Asn
   )
 
   /** Companion class contains a constructor which takes a MaxMind CityResponse. */
@@ -113,11 +125,43 @@ object model {
 
   }
 
+  /** Companion class contains a constructor which takes a MaxMind AsnResponse. */
+  object Asn {
+
+    /**
+     * Constructs an Asn instance from a MaxMind AsnResponse instance.
+     * @param asnResponse MaxMind AsnResponse object
+     * @return Asn
+     */
+    def apply(asnResponse: AsnResponse): Asn =
+      Asn(
+        autonomousSystemNumber = Option(asnResponse.getAutonomousSystemNumber).map(_.toLong),
+        autonomousSystemOrganization = Option(asnResponse.getAutonomousSystemOrganization)
+      )
+  }
+
+  /** Companion class contains a constructor which takes a MaxMind IspResponse. */
+  object Isp {
+
+    /**
+     * Constructs an Isp instance from a MaxMind IspResponse instance.
+     * @param ispResponse MaxMind IspResponse object
+     * @return Isp
+     */
+    def apply(ispResponse: IspResponse): Isp =
+      Isp(
+        name = ispResponse.getIsp,
+        organization = ispResponse.getOrganization,
+        asn = Asn(ispResponse)
+      )
+  }
+
   /** Result of MaxMind lookups */
   final case class IpLookupResult(
     ipLocation: Option[Either[Throwable, IpLocation]],
     isp: Option[Either[Throwable, String]],
     organization: Option[Either[Throwable, String]],
+    asn: Option[Either[Throwable, Asn]],
     domain: Option[Either[Throwable, String]],
     connectionType: Option[Either[Throwable, String]],
     anonymousIp: Option[Either[Throwable, AnonymousIp]]
@@ -129,6 +173,7 @@ object model {
         Option[IpLocation],
         Option[String],
         Option[String],
+        Option[Asn],
         Option[String],
         Option[String],
         Option[AnonymousIp]
@@ -137,11 +182,12 @@ object model {
       val location   = ipLocation.sequence[Error, IpLocation].toValidatedNel
       val provider   = isp.sequence[Error, String].toValidatedNel
       val org        = organization.sequence[Error, String].toValidatedNel
+      val asnRes     = asn.sequence[Error, Asn].toValidatedNel
       val dom        = domain.sequence[Error, String].toValidatedNel
       val connection = connectionType.sequence[Error, String].toValidatedNel
       val anonymous  = anonymousIp.sequence[Error, AnonymousIp].toValidatedNel
 
-      (location, provider, org, dom, connection, anonymous).tupled
+      (location, provider, org, asnRes, dom, connection, anonymous).tupled
     }
   }
 }

--- a/src/test/scala/com.snowplowanalytics.maxmind.iplookups/IpLookupsTest.scala
+++ b/src/test/scala/com.snowplowanalytics.maxmind.iplookups/IpLookupsTest.scala
@@ -47,6 +47,7 @@ object IpLookupsTest {
     ipLocation = unknownHostException(host),
     isp = unknownHostException(host),
     organization = unknownHostException(host),
+    asn = unknownHostException(host),
     domain = unknownHostException(host),
     connectionType = unknownHostException(host),
     anonymousIp = unknownHostException(host)
@@ -72,6 +73,7 @@ object IpLookupsTest {
         continent = "Asia",
         accuracyRadius = 100
       ).asRight.some,
+      new AddressNotFoundException("The address 175.16.199.0 is not in the database.").asLeft.some,
       new AddressNotFoundException("The address 175.16.199.0 is not in the database.").asLeft.some,
       new AddressNotFoundException("The address 175.16.199.0 is not in the database.").asLeft.some,
       new AddressNotFoundException("The address 175.16.199.0 is not in the database.").asLeft.some,
@@ -103,6 +105,10 @@ object IpLookupsTest {
       ).asRight.some,
       "Century Link".asRight.some,
       "Lariat Software".asRight.some,
+      Asn(
+        autonomousSystemNumber = 209L.some,
+        autonomousSystemOrganization = None
+      ).asRight.some,
       new AddressNotFoundException("The address 216.160.83.56 is not in the database.").asLeft.some,
       new AddressNotFoundException("The address 216.160.83.56 is not in the database.").asLeft.some,
       AnonymousIp(
@@ -132,6 +138,10 @@ object IpLookupsTest {
       ).asRight.some,
       "Loud Packet".asRight.some,
       "zudoarichikito_".asRight.some,
+      Asn(
+        autonomousSystemNumber = 35908L.some,
+        autonomousSystemOrganization = None
+      ).asRight.some,
       "shoesfin.NET".asRight.some,
       new AddressNotFoundException("The address 67.43.156.0 is not in the database.").asLeft.some,
       AnonymousIp(
@@ -144,6 +154,7 @@ object IpLookupsTest {
       ).asRight.some
     ),
     "81.2.69.11" -> IpLookupResult(
+      new AddressNotFoundException("The address 81.2.69.11 is not in the database.").asLeft.some,
       new AddressNotFoundException("The address 81.2.69.11 is not in the database.").asLeft.some,
       new AddressNotFoundException("The address 81.2.69.11 is not in the database.").asLeft.some,
       new AddressNotFoundException("The address 81.2.69.11 is not in the database.").asLeft.some,
@@ -166,7 +177,46 @@ object IpLookupsTest {
       new AddressNotFoundException("The address 192.0.2.0 is not in the database.").asLeft.some,
       new AddressNotFoundException("The address 192.0.2.0 is not in the database.").asLeft.some,
       new AddressNotFoundException("The address 192.0.2.0 is not in the database.").asLeft.some,
+      new AddressNotFoundException("The address 192.0.2.0 is not in the database.").asLeft.some,
       new AddressNotFoundException("The address 192.0.2.0 is not in the database.").asLeft.some
+    ),
+    "18.11.120.0" -> IpLookupResult(
+      new AddressNotFoundException("The address 18.11.120.0 is not in the database.").asLeft.some,
+      "Massachusetts Institute of Technology".asRight.some,
+      "Massachusetts Institute of Technology".asRight.some,
+      Asn(
+        autonomousSystemNumber = 3L.some,
+        autonomousSystemOrganization = Some("Massachusetts Institute of Technology")
+      ).asRight.some,
+      new AddressNotFoundException("The address 18.11.120.0 is not in the database.").asLeft.some,
+      new AddressNotFoundException("The address 18.11.120.0 is not in the database.").asLeft.some,
+      AnonymousIp(
+        ipAddress = "18.11.120.0",
+        isAnonymous = false,
+        isAnonymousVpn = false,
+        isHostingProvider = false,
+        isPublicProxy = false,
+        isTorExitNode = false
+      ).asRight.some
+    ),
+    "8.33.20.1" -> IpLookupResult(
+      new AddressNotFoundException("The address 8.33.20.1 is not in the database.").asLeft.some,
+      "Level 3 Communications".asRight.some,
+      "Level 3 Communications".asRight.some,
+      Asn(
+        autonomousSystemNumber = None,
+        autonomousSystemOrganization = None
+      ).asRight.some,
+      new AddressNotFoundException("The address 8.33.20.1 is not in the database.").asLeft.some,
+      new AddressNotFoundException("The address 8.33.20.1 is not in the database.").asLeft.some,
+      AnonymousIp(
+        ipAddress = "8.33.20.1",
+        isAnonymous = false,
+        isAnonymousVpn = false,
+        isHostingProvider = false,
+        isPublicProxy = false,
+        isTorExitNode = false
+      ).asRight.some
     )
   )
 }
@@ -248,7 +298,7 @@ class IpLookupsTest extends Specification with Tables with CatsEffect {
       memCache = true,
       lruCacheSize = 0
     )
-    val expected = IpLookupResult(None, None, None, None, None, None)
+    val expected = IpLookupResult(None, None, None, None, None, None, None)
 
     noFilesLookup
       .flatMap(_.performLookups("67.43.156.0"))
@@ -260,6 +310,7 @@ class IpLookupsTest extends Specification with Tables with CatsEffect {
       "iplocation" ! expected.ipLocation ! actual.ipLocation |
       "isp" ! expected.isp ! actual.isp |
       "organization" ! expected.organization ! actual.organization |
+      "asn" ! expected.asn ! actual.asn |
       "domain" ! expected.domain ! actual.domain |
       "connection type" ! expected.connectionType ! actual.connectionType |
       "anonymous" ! expected.anonymousIp ! actual.anonymousIp | { (_, e, a) =>


### PR DESCRIPTION
Jira ref: [PDP-2423](https://snplow.atlassian.net/browse/PDP-2423)

This PR extracts ASN fields from ISP database and include them in `IpLookupResult`.


[PDP-2423]: https://snplow.atlassian.net/browse/PDP-2423?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ